### PR TITLE
Added padding top to icon menu

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -87,6 +87,7 @@ export const lightboxStyles = ({ imageBackgroundColor }) => `
   .__react_modal_image__icon_menu {
     display: inline-block;
     float: right;
+    padding-top: 10px;
   }
 
   .__react_modal_image__caption {


### PR DESCRIPTION
I used react-modal-image for a side project and was having troubles with the styling of .__react_modal_image__icon_menu (the icons stuck on top of the header) -> screenshots here: 

![without padding top](https://lh3.googleusercontent.com/cePT3Ev8izobY5qjPJ9u9g4BXNMzA2oU6l8Uv5dUG66c1tByQxYKkwYEQCW15TQoyzf7Q7fCPSp_YUo1CGxWciS0189w8Fzd6tP_tBCMPO7rJK5PmEtE0zU6zIUqvluGF8h_TFmjVrPqZqeVJt-kovJzpuaNLv-QGsOHJ-gK_fTgi20ltYpHCXNpwOAunL1hZoODpJSMH1RPNEWa7lRd_cqUlCSALBERlJEzOX6Su2-mQESxSII1cFb4SxvpP9A888axLL5bKtLeNDLxfA58xRdhBWxDJRn18iQ2Z4ULrCVxdtWTreWj5hbVKVFYBRi-BsJ21cw1vixTTxEYLlO5K9lp6vEd8bGn_xah5N9bk87fjHsX9ksKT_RhimyN-w4ezv7_mMcMitHpRqKiI1dI12jad1ovv2a6cosOpXxlogT1BSqf_TeT7NfBEQw0hpDROp-B_PdnCxPqKTtMPBmZzoHAGp29YOtCY7AbVHtj_9ZlJF0w6cAYW4bmRnnb1z0IUemZ0sUffdPvp-Ovr1cwrN5RdYjN3nsSejznVwLuxr8tqW9eH4Jir06nhI0HEO9ixkSDBREvUzbGFdHLDmX7P8R2xEv2HbweLNE4t9-E9xQyAHhbGiLCi-Exj9Wu9qijam2I68H9KqrLCRpCckHMuoC_GY4-QdKdv223c7NmqXKzr96zgc3YXGJghIXJjqdSFs8uAojgcZPRiT9VlFsIoug=w829-h438-no?authuser=0)

![with padding top](https://lh3.googleusercontent.com/sVMomE_Y7y63t8QP1QccuA4C4mmh-GWUEWzlRpunmm34dT2EyhVc6Ax8vmgvi5hXZVTRznZJfhYszEcBqS-vGTD7CJ8oML1F_P9z9KmK3pKtM6CYjkuW554yx4-cHMogeRT_j3I0SSS1aAyiDzwQaniaCCDabnwJRpWH2E8VQFtx4lVK5swn7I2tWbY5mAu_mU_ULOre1dAkgs6IBKIOoi8xv2TbHLYYMidFzY5flK7dhLAyylHE9rMS3tikg-mWYeo9ONIThGgWnrUvxwk2gQoruKkZz1hejgo_WU1-XD2QUMOKaCClfvm7IrO6w6KrQ5cf4Erpr6-t6HtkXTKaljlMaVKgIK4ZC7pPlf2Z9HjO5fTcuR6yYV5dyZfIseokfuplYrhRKGTxa8HAdOeiumdXm693Y0DWI7u09STWQ2FK8_AZL2_IpqaFrYPD_y4JkmJ7rjsz7359pZcxb1Y0WlSM75ntXSpk_uAIkrDm0ItjPCkT1LnzuedFk5lAvhY8_a7shmjGh0elXEmr0G_GPwslHV00VE6PSOHUPb5-epRCMMFG9l7SoWZ7lSvW4W9tT0rjLnR5fhVFOhw8faiYPzZMKOZ63PNkOAyi-UNC-Vny6h0kRtri9lbPujJ0_raxwNv1SOwbfRyh3fZzv3qKqoP-OSsJdsK62ymWptXXnnWbB9kwnwQInk0UiW7f9dZguI59Z-xVCwqXPdrv3i-pO8I=w831-h438-no?authuser=0)

So I think adding a padding-top with the same value as the one for .__react_modal_image__caption fixes the issue.